### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,9 +12,9 @@
     ],
     "require": {
         "php": ">=7.0",
-        "illuminate/database": "^5.4",
-        "illuminate/support": "^5.4",
-        "illuminate/validation": "^5.4",
+        "illuminate/database": "5.4.* || 5.5.*",
+        "illuminate/support": "5.4.* || 5.5.*",
+        "illuminate/validation": "5.4.* || 5.5.*",
         "saritasa/php-common": "^1.0",
         "propaganistas/laravel-phone": "^3.0.4"
     },


### PR DESCRIPTION
Laravel doesn't follow semver. So having `^5.x`, `5.*` or `>=5.x` will mean that composer will install a future version even though that version breaks the package.